### PR TITLE
feat(sqlite): add wasm32 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,6 +261,18 @@ jobs:
           - name: '[m], indexeddb stores, no crypto'
             cmd: matrix-sdk-indexeddb-stores-no-crypto
 
+          # The sqlite wasm-pack tests require OPFS and a dedicated worker,
+          # which the Node.js runner does not provide, so only run the clippy
+          # check here. The tests can be run locally with e.g.
+          # `cargo xtask ci wasm-pack sqlite-all-features --runner chrome`.
+          - name: '[m]-sqlite'
+            cmd: sqlite-all-features
+            check_only: true
+
+          - name: '[m], sqlite stores'
+            cmd: matrix-sdk-sqlite-stores
+            check_only: true
+
     steps:
       - name: Checkout the repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2351,11 +2351,11 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2817,6 +2817,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
+name = "indexed_db_futures"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ff41758cbd104e91033bb53bc449bec7eea65652960c81eddf3fc146ecea19"
+dependencies = [
+ "accessory",
+ "cfg-if",
+ "delegate-display",
+ "derive_more 2.0.1",
+ "fancy_constructor",
+ "indexed_db_futures_macros_internal",
+ "js-sys",
+ "sealed",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "indexed_db_futures_macros_internal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caeba94923b68f254abef921cea7e7698bf4675fdd89d7c58bf1ed885b49a27d"
+dependencies = [
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3094,9 +3128,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.35.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3710,6 +3744,8 @@ dependencies = [
  "async-trait",
  "deadpool 0.13.0",
  "deadpool-sync",
+ "getrandom 0.2.15",
+ "getrandom 0.4.2",
  "glob",
  "itertools 0.14.0",
  "matrix-sdk-base",
@@ -3722,15 +3758,21 @@ dependencies = [
  "rmp-serde",
  "ruma",
  "rusqlite",
+ "send_wrapper",
  "serde",
  "serde_json",
  "serde_path_to_error",
  "similar-asserts",
+ "sqlite-wasm-rs",
+ "sqlite-wasm-vfs",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
  "vodozemac",
+ "wasm-bindgen-test",
+ "web-time",
  "zeroize",
 ]
 
@@ -5093,6 +5135,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "rtoolbox"
 version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5281,9 +5333,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.37.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+checksum = "a0d2b0146dd9661bf67bb107c0bb2a55064d556eeb3fc314151b957f313bcd4e"
 dependencies = [
  "bitflags 2.10.0",
  "fallible-iterator",
@@ -5291,6 +5343,7 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -5518,6 +5571,12 @@ dependencies = [
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "sentry"
@@ -5899,6 +5958,34 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "sqlite-wasm-vfs"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7a5c9ac229421d577bb5a9bb59048838509958b218dd4e0b3c1214a87c361e"
+dependencies = [
+ "indexed_db_futures",
+ "js-sys",
+ "rsqlite-vfs",
+ "thiserror 2.0.18",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/matrix-sdk-sqlite/CHANGELOG.md
+++ b/crates/matrix-sdk-sqlite/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 <!-- changelog start -->
 
+## Unreleased
+
+### Features
+
+- Add support for the `wasm32-unknown-unknown` target. On WASM the stores use a
+  single `rusqlite` connection backed by the OPFS `sahpool` VFS instead of a
+  `deadpool` connection pool. The stores must be created and used from a single
+  dedicated Web Worker, and opening the same stores from several tabs or
+  workers concurrently is not supported; see the `SqliteStoreConfig`
+  documentation for details.
+
+### Refactor
+
+- Upgrade `rusqlite` from 0.37 to 0.39, which provides the SQLite WASM backend.
+  Native builds now link `libsqlite3-sys` 0.37; when linking against a system
+  SQLite (i.e. without the `bundled` feature), the minimum supported SQLite
+  version may change accordingly.
+
 ## [0.18.0](https://github.com/matrix-org/matrix-rust-sdk/tree/0.18.0) - 2026-06-02
 
 No significant changes.

--- a/crates/matrix-sdk-sqlite/Cargo.toml
+++ b/crates/matrix-sdk-sqlite/Cargo.toml
@@ -29,26 +29,44 @@ experimental-push-secrets = [
 [dependencies]
 as_variant.workspace = true
 async-trait.workspace = true
-deadpool = { version = "0.13", default-features = false, features = ["managed", "rt_tokio_1"] }
-deadpool-sync = { version = "0.2", default-features = false }
 itertools.workspace = true
 matrix-sdk-base = { workspace = true, optional = true }
 matrix-sdk-crypto = { workspace = true, optional = true }
 matrix-sdk-store-encryption.workspace = true
-num_cpus = { version = "1.17.0", default-features = false }
 rmp-serde.workspace = true
 ruma.workspace = true
-rusqlite = { version = "0.37.0", default-features = false, features = ["limits"] }
+rusqlite = { version = "0.39.0", default-features = false, features = ["limits", "cache", "fallible_uint"] }
 serde.workspace = true
 serde_json.workspace = true
 serde_path_to_error = { version = "0.1.20", default-features = false }
 thiserror.workspace = true
-tokio = { workspace = true, features = ["fs"] }
 tracing.workspace = true
 vodozemac.workspace = true
 zeroize.workspace = true
 
-[dev-dependencies]
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+deadpool = { version = "0.13", default-features = false, features = ["managed", "rt_tokio_1"] }
+deadpool-sync = { version = "0.2", default-features = false }
+num_cpus = { version = "1.17.0", default-features = false }
+tokio = { workspace = true, features = ["fs", "sync"] }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+sqlite-wasm-rs = { version = "0.5", default-features = false }
+sqlite-wasm-vfs = "0.2"
+send_wrapper = "0.6"
+tokio = { workspace = true }
+# The following dependencies are not used directly. They only enable the
+# WASM-compatible features of transitive dependencies.
+matrix-sdk-common = { workspace = true, features = ["js"] }
+getrandom_02 = { package = "getrandom", version = "0.2", features = ["js"] }
+getrandom_04 = { package = "getrandom", version = "0.4", features = ["wasm_js"] }
+uuid = { workspace = true, features = ["js", "v4"] }
+web-time = { version = "1.1.0", features = ["serde"] }
+
+# The bulk of the test suite (including the store integration test macros)
+# only runs natively; the corresponding dev-dependencies do not build for WASM
+# (e.g. `tokio`'s multi-threaded runtime), so they are target-gated.
+[target.'cfg(not(target_family = "wasm"))'.dev-dependencies]
 assert_matches.workspace = true
 glob = "0.3.3"
 matrix-sdk-base = { workspace = true, features = ["testing"] }
@@ -59,6 +77,9 @@ matrix-sdk-test-utils.workspace = true
 similar-asserts.workspace = true
 tempfile.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+wasm-bindgen-test = "0.3.50"
 
 [lints]
 workspace = true

--- a/crates/matrix-sdk-sqlite/src/connection.rs
+++ b/crates/matrix-sdk-sqlite/src/connection.rs
@@ -12,257 +12,499 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! An implementation of `deadpool` for `rusqlite`.
+//! Connection management for `matrix-sdk-sqlite`.
 //!
-//! Initially, we were using `deadpool-sqlite`, that is also using `rusqlite` as
-//! the SQLite interface. However, in the implementation of
-//! [`deadpool::managed::Manager`], when recycling an object (i.e. an SQLite
-//! connection), [a SQL query is run to detect whether the connection is still
-//! alive][connection-test]. It creates performance issues:
+//! Two backends are provided behind `cfg(target_family)`:
 //!
-//! 1. It runs a prepared SQL query, which has a non-negligle cost. Imagine each
-//!    connection is used to run on average one query; when recycled, a second
-//!    query was constantly run. Even if it's a simple query, it requires to
-//!    prepare a statement, to run and to query it.
-//! 2. The SQL query was run in a blocking task. Indeed,
-//!    `deadpool_runtime::spawn_blocking` is used (via
-//!    `deadpool_sync::SyncWrapper::interact`), which includes [blocking the
-//!    thread, acquiring a lock][spawn_blocking] etc. All this has more
-//!    performance cost.
-//!
-//! Measures have shown it is a performance bottleneck for us, especially on
-//! Android. Why specifically on Android and not other systems? This is still
-//! unclear at the time of writing (2025-11-11), despites having spent several
-//! days digging and trying to find an answer to this question.
-//!
-//! We have tried to use another approach to test the aliveness of the
-//! connections without running queries. It has involved patching `rusqlite` to
-//! add more bindings to SQLite, and patching `deadpool` itself, but without any
-//! successful results.
-//!
-//! Finally, we have started questioning the reason of this test: why testing
-//! whether the connection was still alive? After all, there is no reason a
-//! connection should die in our case:
-//!
-//! - all connections are local,
-//! - all interactions are behind [WAL], which is local only,
-//! - even if for an unknown reason the connection died, using it next time
-//!   would create an error… exactly what would happen when recycling the
-//!   connection.
-//!
-//! Consequently, we have created a new implementation of `deadpool` for
-//! `rusqlite` that doesn't test the aliveness of the connections when recycled.
-//! We assume they are all alive.
-//!
-//! This implementation is, at the time of writing (2025-11-11):
-//!
-//! - 3.5 times faster on Android than `deadpool-sqlite`, removing the lock and
-//!   thread contention entirely,
-//! - 2 times faster on iOS.
-//!
-//! [connection-test]: https://github.com/deadpool-rs/deadpool/blob/d6f7d58756f0cc7bdd1f3d54d820c1332d67e4d5/crates/deadpool-sqlite/src/lib.rs#L80-L100
-//! [spawn_blocking]: https://github.com/deadpool-rs/deadpool/blob/d6f7d58756f0cc7bdd1f3d54d820c1332d67e4d5/crates/deadpool-sync/src/lib.rs#L113-L131
-//! [WAL]: https://www.sqlite.org/wal.html
+//! - **Native** (`native` module): a custom [`deadpool`] implementation for
+//!   `rusqlite` with a pool of connections. See the [`native`] module
+//!   documentation for the rationale behind the custom implementation.
+//! - **WASM** (`wasm` module): a single `rusqlite::Connection` backed by the
+//!   OPFS `sahpool` VFS. There is no pool, because the module runs inside a
+//!   single Web Worker. See the [`wasm`] module documentation for details.
 
-use std::{convert::Infallible, path::PathBuf, sync::Arc, time::Duration};
+// ===========================================================================
+// Native (non-WASM) connection implementation — deadpool-based
+// ===========================================================================
 
-pub use deadpool::managed::reexports::*;
-use deadpool::managed::{self, Metrics, PoolConfig, RecycleError};
-use deadpool_sync::SyncWrapper;
-use tokio::sync::Mutex;
-use tracing::{info, warn};
+#[cfg(not(target_family = "wasm"))]
+mod native {
+    //! An implementation of `deadpool` for `rusqlite`.
+    //!
+    //! Initially, we were using `deadpool-sqlite`, that is also using
+    //! `rusqlite` as the SQLite interface. However, in the implementation of
+    //! [`deadpool::managed::Manager`], when recycling an object (i.e. an SQLite
+    //! connection), [a SQL query is run to detect whether the connection is
+    //! still alive][connection-test]. It creates performance issues:
+    //!
+    //! 1. It runs a prepared SQL query, which has a non-negligle cost. Imagine
+    //!    each connection is used to run on average one query; when recycled, a
+    //!    second query was constantly run. Even if it's a simple query, it
+    //!    requires to prepare a statement, to run and to query it.
+    //! 2. The SQL query was run in a blocking task. Indeed,
+    //!    `deadpool_runtime::spawn_blocking` is used (via
+    //!    `deadpool_sync::SyncWrapper::interact`), which includes [blocking the
+    //!    thread, acquiring a lock][spawn_blocking] etc. All this has more
+    //!    performance cost.
+    //!
+    //! Measures have shown it is a performance bottleneck for us, especially on
+    //! Android. Why specifically on Android and not other systems? This is
+    //! still unclear at the time of writing (2025-11-11), despites having spent
+    //! several days digging and trying to find an answer to this question.
+    //!
+    //! We have tried to use another approach to test the aliveness of the
+    //! connections without running queries. It has involved patching `rusqlite`
+    //! to add more bindings to SQLite, and patching `deadpool` itself, but
+    //! without any successful results.
+    //!
+    //! Finally, we have started questioning the reason of this test: why
+    //! testing whether the connection was still alive? After all, there is no
+    //! reason a connection should die in our case:
+    //!
+    //! - all connections are local,
+    //! - all interactions are behind [WAL], which is local only,
+    //! - even if for an unknown reason the connection died, using it next time
+    //!   would create an error… exactly what would happen when recycling the
+    //!   connection.
+    //!
+    //! Consequently, we have created a new implementation of `deadpool` for
+    //! `rusqlite` that doesn't test the aliveness of the connections when
+    //! recycled. We assume they are all alive.
+    //!
+    //! This implementation is, at the time of writing (2025-11-11):
+    //!
+    //! - 3.5 times faster on Android than `deadpool-sqlite`, removing the lock
+    //!   and thread contention entirely,
+    //! - 2 times faster on iOS.
+    //!
+    //! [connection-test]: https://github.com/deadpool-rs/deadpool/blob/d6f7d58756f0cc7bdd1f3d54d820c1332d67e4d5/crates/deadpool-sqlite/src/lib.rs#L80-L100
+    //! [spawn_blocking]: https://github.com/deadpool-rs/deadpool/blob/d6f7d58756f0cc7bdd1f3d54d820c1332d67e4d5/crates/deadpool-sync/src/lib.rs#L113-L131
+    //! [WAL]: https://www.sqlite.org/wal.html
 
-/// The default runtime used by `matrix-sdk-sqlite` for `deadpool`.
-pub const RUNTIME: Runtime = Runtime::Tokio1;
+    use std::{convert::Infallible, path::PathBuf, sync::Arc, time::Duration};
 
-deadpool::managed_reexports!(
-    "matrix-sdk-sqlite",
-    Manager,
-    managed::Object<Manager>,
-    rusqlite::Error,
-    Infallible
-);
+    pub use deadpool::managed::reexports::*;
+    use deadpool::managed::{self, Metrics, PoolConfig, RecycleError};
+    use deadpool_sync::SyncWrapper;
+    use tokio::sync::Mutex;
+    use tracing::{info, warn};
 
-/// Type representing a connection to SQLite from the [`Pool`].
-pub type Connection = Object;
+    /// The default runtime used by `matrix-sdk-sqlite` for `deadpool`.
+    pub const RUNTIME: Runtime = Runtime::Tokio1;
 
-/// [`Manager`][managed::Manager] for creating and recycling SQLite
-/// [`Connection`]s.
-#[derive(Debug)]
-pub struct Manager {
-    pub(crate) database_path: PathBuf,
-}
+    deadpool::managed_reexports!(
+        "matrix-sdk-sqlite",
+        Manager,
+        managed::Object<Manager>,
+        rusqlite::Error,
+        Infallible
+    );
 
-impl Manager {
-    /// Creates a new [`Manager`] for a database.
-    #[must_use]
-    pub fn new(database_path: PathBuf) -> Self {
-        Self { database_path }
+    /// Type representing a connection to SQLite from the [`Pool`].
+    pub type Connection = Object;
+
+    /// [`Manager`][managed::Manager] for creating and recycling SQLite
+    /// [`Connection`]s.
+    #[derive(Debug)]
+    pub struct Manager {
+        pub(crate) database_path: PathBuf,
     }
-}
 
-impl managed::Manager for Manager {
-    type Type = SyncWrapper<rusqlite::Connection>;
-    type Error = rusqlite::Error;
-
-    async fn create(&self) -> Result<Self::Type, Self::Error> {
-        let path = self.database_path.clone();
-        SyncWrapper::new(RUNTIME, move || rusqlite::Connection::open(path)).await
-    }
-
-    async fn recycle(
-        &self,
-        conn: &mut Self::Type,
-        _: &Metrics,
-    ) -> managed::RecycleResult<Self::Error> {
-        if conn.is_mutex_poisoned() {
-            return Err(RecycleError::Message(
-                "Mutex is poisoned. Connection is considered unusable.".into(),
-            ));
+    impl Manager {
+        /// Creates a new [`Manager`] for a database.
+        #[must_use]
+        pub fn new(database_path: PathBuf) -> Self {
+            Self { database_path }
         }
+    }
+
+    impl managed::Manager for Manager {
+        type Type = SyncWrapper<rusqlite::Connection>;
+        type Error = rusqlite::Error;
+
+        async fn create(&self) -> Result<Self::Type, Self::Error> {
+            let path = self.database_path.clone();
+            SyncWrapper::new(RUNTIME, move || rusqlite::Connection::open(path)).await
+        }
+
+        async fn recycle(
+            &self,
+            conn: &mut Self::Type,
+            _: &Metrics,
+        ) -> managed::RecycleResult<Self::Error> {
+            if conn.is_mutex_poisoned() {
+                return Err(RecycleError::Message(
+                    "Mutex is poisoned. Connection is considered unusable.".into(),
+                ));
+            }
+            Ok(())
+        }
+    }
+
+    /// Gracefully close the store-owned write connection.
+    ///
+    /// Callers are expected to remove the enclosing [`SqliteConnections`] from
+    /// the store before calling this helper so no new write acquisitions can
+    /// happen through the store API.
+    ///
+    /// 1. Waits for any in-flight write to complete by acquiring the lock.
+    /// 2. Runs a WAL checkpoint (TRUNCATE) to flush pending data to the main
+    ///    database file and release WAL locks.
+    /// 3. Drops the store-owned `Arc` on a blocking thread.
+    ///
+    /// This is still best effort: if another cloned `Arc` or an
+    /// `OwnedMutexGuard<Connection>` is still alive elsewhere, the underlying
+    /// SQLite connection may remain alive until that handle is dropped.
+    pub async fn close_connection(write_connection: Arc<Mutex<Connection>>) {
+        // Acquire the lock to wait for any in-flight write to complete.
+        let guard = write_connection.lock().await;
+
+        // Flush WAL and release locks while we still own the connection.
+        let _ = guard
+            .interact(|raw| {
+                raw.execute_batch("PRAGMA locking_mode = NORMAL; PRAGMA wal_checkpoint(TRUNCATE);")
+                    .ok();
+            })
+            .await;
+
+        drop(guard);
+
+        // Drop the store-owned Arc on a blocking thread.
+        let _ = tokio::task::spawn_blocking(move || drop(write_connection)).await;
+    }
+
+    /// Live database connections held by each SQLite store.
+    ///
+    /// Wrapped in `Option<SqliteConnections>` guarded by a `Mutex` inside each
+    /// store; `Some` means the store is active, `None` means it is closed.
+    pub(crate) struct SqliteConnections {
+        /// The pool of read connections.
+        pub pool: Pool,
+        /// The dedicated write connection.
+        ///
+        /// This lives behind `Arc<Mutex<_>>` so stores can clone the `Arc` and
+        /// obtain an `OwnedMutexGuard<Connection>` without holding the outer
+        /// `connections` mutex across await points.
+        pub write_connection: Arc<Mutex<Connection>>,
+    }
+
+    /// Close a store by taking its connections out.
+    ///
+    /// After this returns, any new call to `read()` or `write()` through the
+    /// store will fail with [`crate::error::Error::StoreClosed`] until
+    /// [`reopen_connections`] is called.
+    ///
+    /// Idempotent: if the store is already closed this is a no-op.
+    pub(crate) async fn close_connections(
+        connections: &Mutex<Option<SqliteConnections>>,
+        label: &str,
+    ) {
+        let mut guard = connections.lock().await;
+        let Some(conns) = guard.take() else {
+            // Already closed — idempotent.
+            return;
+        };
+
+        let SqliteConnections { pool, write_connection } = conns;
+
+        // Close the pool. Idle read connections are dropped immediately;
+        // in-flight reads complete and their connections are discarded (not
+        // recycled) on release. New pool.get() calls return PoolError::Closed.
+        pool.close();
+
+        let status = pool.status();
+        info!(
+            size = status.size,
+            max_size = status.max_size,
+            available = status.available,
+            "{label} pause: pool closed"
+        );
+
+        // Close the write connection: wait for any in-flight write to finish,
+        // run a WAL checkpoint, then drop on a blocking thread.
+        close_connection(write_connection).await;
+
+        let status = pool.status();
+        info!(
+            size = status.size,
+            max_size = status.max_size,
+            available = status.available,
+            "{label} pause: write connection released"
+        );
+
+        // Wait for any in-flight read connections to drain.
+        // The write connection has already been released above, so
+        // pool.status().size == 0 now correctly means every connection is gone
+        // and no SQLite file locks are held.
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+        while pool.status().size > 0 {
+            if tokio::time::Instant::now() >= deadline {
+                let status = pool.status();
+                warn!(
+                    size = status.size,
+                    max_size = status.max_size,
+                    available = status.available,
+                    "Timed out waiting for SQLite pool connections to drain"
+                );
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    /// Resume a store by rebuilding its connections.
+    ///
+    /// Idempotent: if the store is already active this is a no-op.
+    pub(crate) async fn reopen_connections(
+        connections: &Mutex<Option<SqliteConnections>>,
+        db_path: PathBuf,
+        pool_config: PoolConfig,
+        runtime_config: crate::RuntimeConfig,
+    ) -> crate::error::Result<()> {
+        use crate::utils::SqliteAsyncConnExt as _;
+
+        let mut guard = connections.lock().await;
+        if guard.is_some() {
+            // Not closed — idempotent.
+            return Ok(());
+        }
+
+        // Rebuild the pool (connections are created lazily on first get()).
+        let pool = Pool::builder(Manager::new(db_path))
+            .config(pool_config)
+            .runtime(RUNTIME)
+            .build()
+            .map_err(|e| crate::error::Error::InvalidData {
+                details: format!("Failed to rebuild connection pool: {e}"),
+            })?;
+
+        let write_conn = pool.get().await?;
+        // Re-apply runtime config (WAL mode, busy timeout, etc.)
+        write_conn.apply_runtime_config(runtime_config).await?;
+
+        *guard =
+            Some(SqliteConnections { pool, write_connection: Arc::new(Mutex::new(write_conn)) });
 
         Ok(())
     }
 }
 
-/// Gracefully close the store-owned write connection.
-///
-/// Callers are expected to remove the enclosing [`SqliteConnections`] from the
-/// store before calling this helper so no new write acquisitions can happen
-/// through the store API.
-///
-/// 1. Waits for any in-flight write to complete by acquiring the lock.
-/// 2. Runs a WAL checkpoint (TRUNCATE) to flush pending data to the main
-///    database file and release WAL locks.
-/// 3. Drops the store-owned `Arc` on a blocking thread.
-///
-/// This is still best effort: if another cloned `Arc` or an
-/// `OwnedMutexGuard<Connection>` is still alive elsewhere, the underlying
-/// SQLite connection may remain alive until that handle is dropped.
-pub async fn close_connection(write_connection: Arc<Mutex<Connection>>) {
-    // Acquire the lock to wait for any in-flight write to complete.
-    let guard = write_connection.lock().await;
+#[cfg(not(target_family = "wasm"))]
+pub use native::*;
+// Target-neutral aliases, so that shared code (e.g. `error.rs`) does not need
+// to distinguish between the pool-based native backend and the single
+// connection WASM backend.
+#[cfg(not(target_family = "wasm"))]
+pub use native::{CreatePoolError as OpenConnectionError, PoolError as AcquireConnectionError};
+#[cfg(not(target_family = "wasm"))]
+pub(crate) use native::{SqliteConnections, close_connections, reopen_connections};
 
-    // Flush WAL and release locks while we still own the connection.
-    let _ = guard
-        .interact(|raw| {
-            raw.execute_batch("PRAGMA locking_mode = NORMAL; PRAGMA wal_checkpoint(TRUNCATE);")
-                .ok();
-        })
-        .await;
+// ===========================================================================
+// WASM connection implementation — single connection, no pool
+// ===========================================================================
 
-    drop(guard);
+#[cfg(target_family = "wasm")]
+mod wasm {
+    use std::{cell::RefCell, rc::Rc};
 
-    // Drop the store-owned Arc on a blocking thread.
-    let _ = tokio::task::spawn_blocking(move || drop(write_connection)).await;
-}
+    use send_wrapper::SendWrapper;
+    use tracing::{info, warn};
 
-/// Live database connections held by each SQLite store.
-///
-/// Wrapped in `Option<SqliteConnections>` guarded by a `Mutex` inside each
-/// store; `Some` means the store is active, `None` means it is closed.
-pub(crate) struct SqliteConnections {
-    /// The pool of read connections.
-    pub pool: Pool,
-    /// The dedicated write connection.
+    /// A thin wrapper around `rusqlite::Connection` for WASM.
     ///
-    /// This lives behind `Arc<Mutex<_>>` so stores can clone the `Arc` and
-    /// obtain an `OwnedMutexGuard<Connection>` without holding the outer
-    /// `connections` mutex across await points.
-    pub write_connection: Arc<Mutex<Connection>>,
-}
+    /// Uses `SendWrapper<Rc<RefCell>>` to satisfy the `Send + Sync` bounds
+    /// required by the async store traits.
+    ///
+    /// `SendWrapper` panics at runtime if accessed from a thread other than the
+    /// one that created it. This is safe under the expected WASM deployment:
+    ///   1. The entire WASM module runs inside a single Web Worker.
+    ///   2. All calls are dispatched to that Worker via message passing.
+    ///   3. The `Connection` is created and accessed exclusively on the Worker
+    ///      thread, so `SendWrapper`'s thread check always passes.
+    ///
+    /// This applies to both WASM-without-atomics (trivially single-threaded)
+    /// and WASM-with-atomics (single Worker, message-passing dispatch). Using
+    /// `Rc<RefCell>` instead of `Arc<Mutex>` avoids unnecessary atomic overhead
+    /// on the inherently single-threaded Worker.
+    pub struct Connection {
+        inner: SendWrapper<Rc<RefCell<rusqlite::Connection>>>,
+    }
 
-/// Close a store by taking its connections out.
-///
-/// After this returns, any new call to `read()` or `write()` through the
-/// store will fail with [`crate::error::Error::StoreClosed`] until
-/// [`reopen_connections`] is called.
-///
-/// Idempotent: if the store is already closed this is a no-op.
-pub(crate) async fn close_connections(connections: &Mutex<Option<SqliteConnections>>, label: &str) {
-    let mut guard = connections.lock().await;
-    let Some(conns) = guard.take() else {
-        // Already closed — idempotent.
-        return;
-    };
-
-    let SqliteConnections { pool, write_connection } = conns;
-
-    // Close the pool. Idle read connections are dropped immediately;
-    // in-flight reads complete and their connections are discarded (not
-    // recycled) on release. New pool.get() calls return PoolError::Closed.
-    pool.close();
-
-    let status = pool.status();
-    info!(
-        size = status.size,
-        max_size = status.max_size,
-        available = status.available,
-        "{label} pause: pool closed"
-    );
-
-    // Close the write connection: wait for any in-flight write to finish,
-    // run a WAL checkpoint, then drop on a blocking thread.
-    close_connection(write_connection).await;
-
-    let status = pool.status();
-    info!(
-        size = status.size,
-        max_size = status.max_size,
-        available = status.available,
-        "{label} pause: write connection released"
-    );
-
-    // Wait for any in-flight read connections to drain.
-    // The write connection has already been released above, so
-    // pool.status().size == 0 now correctly means every connection is gone
-    // and no SQLite file locks are held.
-    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-    while pool.status().size > 0 {
-        if tokio::time::Instant::now() >= deadline {
-            let status = pool.status();
-            warn!(
-                size = status.size,
-                max_size = status.max_size,
-                available = status.available,
-                "Timed out waiting for SQLite pool connections to drain"
-            );
-            break;
+    impl Connection {
+        pub(crate) fn new(conn: rusqlite::Connection) -> Self {
+            Self { inner: SendWrapper::new(Rc::new(RefCell::new(conn))) }
         }
-        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        /// Run a synchronous closure against the underlying
+        /// `rusqlite::Connection`.
+        ///
+        /// This is the WASM equivalent of `SyncWrapper::interact` — the closure
+        /// runs inline (no thread hop) and cannot be cancelled, so unlike the
+        /// native version it is infallible.
+        pub fn interact<F, R>(&self, f: F) -> R
+        where
+            F: FnOnce(&mut rusqlite::Connection) -> R,
+        {
+            f(&mut self.inner.borrow_mut())
+        }
+    }
+
+    impl Clone for Connection {
+        fn clone(&self) -> Self {
+            Self { inner: SendWrapper::new(Rc::clone(&self.inner)) }
+        }
+    }
+
+    /// Error when acquiring a connection.
+    ///
+    /// Equivalent of the native `PoolError`.
+    #[derive(Debug, thiserror::Error)]
+    pub enum AcquireConnectionError {
+        #[error("WASM SQLite error: {0}")]
+        Backend(#[from] rusqlite::Error),
+    }
+
+    /// Error when opening the database connection.
+    ///
+    /// Equivalent of the native `CreatePoolError`.
+    #[derive(Debug, thiserror::Error)]
+    pub enum OpenConnectionError {
+        #[error("WASM SQLite init error: {0}")]
+        Backend(#[from] rusqlite::Error),
+    }
+
+    pub(crate) struct SqliteConnections {
+        pub conn: Connection,
+        pub write_connection: std::sync::Arc<tokio::sync::Mutex<Connection>>,
+    }
+
+    impl SqliteConnections {
+        pub fn new(conn: Connection) -> Self {
+            let write_conn = conn.clone();
+            Self {
+                conn,
+                write_connection: std::sync::Arc::new(tokio::sync::Mutex::new(write_conn)),
+            }
+        }
+    }
+
+    pub(crate) async fn close_connections(
+        connections: &tokio::sync::Mutex<Option<SqliteConnections>>,
+        label: &str,
+    ) {
+        let mut guard = connections.lock().await;
+        if let Some(conns) = guard.take() {
+            // Flush WAL before dropping so OPFS has a compact checkpointed
+            // database before the worker releases its sync access handles.
+            if let Err(e) =
+                conns.conn.interact(|raw| raw.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);"))
+            {
+                warn!("{label} pause: WAL checkpoint error: {e}");
+            }
+            // Drop `conns` — when the last Rc<RefCell<Connection>> reference
+            // count reaches zero, rusqlite::Connection::drop calls
+            // sqlite3_close which triggers the VFS xClose/xSync.
+            drop(conns);
+            info!("{label} pause: WASM connection closed");
+        }
+    }
+
+    pub(crate) async fn reopen_connections(
+        connections: &tokio::sync::Mutex<Option<SqliteConnections>>,
+        db_name: &str,
+        runtime_config: crate::RuntimeConfig,
+    ) -> crate::error::Result<()> {
+        use crate::utils::SqliteAsyncConnExt as _;
+
+        let mut guard = connections.lock().await;
+        if guard.is_some() {
+            return Ok(());
+        }
+
+        let conn =
+            open_wasm_connection(db_name).await.map_err(|e| crate::error::Error::InvalidData {
+                details: format!("Failed to reopen WASM connection: {e}"),
+            })?;
+        conn.apply_runtime_config(runtime_config).await?;
+        *guard = Some(SqliteConnections::new(conn));
+
+        Ok(())
+    }
+
+    /// Open a WASM database connection using the OPFS sahpool VFS.
+    pub(crate) async fn open_wasm_connection(
+        db_name: &str,
+    ) -> Result<Connection, OpenConnectionError> {
+        use sqlite_wasm_vfs::sahpool::{OpfsSAHPoolCfgBuilder, install as install_sahpool};
+
+        fn map_vfs_err(
+            context: &str,
+            error: sqlite_wasm_vfs::sahpool::OpfsSAHError,
+        ) -> OpenConnectionError {
+            OpenConnectionError::Backend(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error::new(rusqlite::ffi::SQLITE_CANTOPEN),
+                Some(format!("{context}: {error:?}")),
+            ))
+        }
+
+        // The worker opens four SDK databases. With WAL enabled, each database
+        // needs two file slots (main database + WAL file), so sahpool needs
+        // more slots than its single-database default of 6.
+        const OPFS_SAHPOOL_MINIMUM_CAPACITY: u32 = 16;
+        let cfg =
+            OpfsSAHPoolCfgBuilder::new().initial_capacity(OPFS_SAHPOOL_MINIMUM_CAPACITY).build();
+
+        let util = install_sahpool::<sqlite_wasm_rs::WasmOsCallback>(&cfg, true)
+            .await
+            .map_err(|e| map_vfs_err("sahpool VFS install failed", e))?;
+
+        // `install` is idempotent: if the VFS was already installed (e.g. by
+        // another store or the embedding application), our `initial_capacity`
+        // is ignored. The pool does not grow on demand — opening a database
+        // fails once all slots are taken — so explicitly ensure the capacity
+        // we need is actually available.
+        util.reserve_minimum_capacity(OPFS_SAHPOOL_MINIMUM_CAPACITY)
+            .await
+            .map_err(|e| map_vfs_err("failed to reserve sahpool VFS capacity", e))?;
+
+        let raw = rusqlite::Connection::open(db_name).map_err(OpenConnectionError::Backend)?;
+
+        for (name, statement) in [
+            ("foreign_keys", "PRAGMA foreign_keys = ON;"),
+            // The page size must be set before the database is created and
+            // cannot be changed anymore once WAL mode is entered, so this must
+            // come before the `journal_mode` PRAGMA.
+            ("page_size", "PRAGMA page_size = 4096;"),
+            // The sahpool VFS does not implement the shared-memory primitives
+            // (`xShmMap` & co.), so SQLite silently refuses to switch to WAL
+            // unless the connection is in exclusive locking mode, where the
+            // WAL index lives on the heap instead. Exclusive locking is fine
+            // here: there is only ever a single connection per database.
+            // See <https://www.sqlite.org/wal.html#noshm>.
+            ("locking_mode", "PRAGMA locking_mode = EXCLUSIVE;"),
+            ("journal_mode", "PRAGMA journal_mode = WAL;"),
+            ("synchronous", "PRAGMA synchronous = NORMAL;"),
+            ("temp_store", "PRAGMA temp_store = MEMORY;"),
+        ] {
+            raw.execute_batch(statement).map_err(|e| {
+                OpenConnectionError::Backend(match e {
+                    rusqlite::Error::SqliteFailure(err, message) => rusqlite::Error::SqliteFailure(
+                        err,
+                        Some(format!(
+                            "failed to apply PRAGMA {name} to {db_name}: {}",
+                            message.unwrap_or_else(|| err.to_string())
+                        )),
+                    ),
+                    other => other,
+                })
+            })?;
+        }
+
+        Ok(Connection::new(raw))
     }
 }
 
-/// Resume a store by rebuilding its connections.
-///
-/// Idempotent: if the store is already active this is a no-op.
-pub(crate) async fn reopen_connections(
-    connections: &Mutex<Option<SqliteConnections>>,
-    db_path: PathBuf,
-    pool_config: PoolConfig,
-    runtime_config: crate::RuntimeConfig,
-) -> crate::error::Result<()> {
-    use crate::utils::SqliteAsyncConnExt as _;
-
-    let mut guard = connections.lock().await;
-    if guard.is_some() {
-        // Not closed — idempotent.
-        return Ok(());
-    }
-
-    // Rebuild the pool (connections are created lazily on first get()).
-    let pool =
-        Pool::builder(Manager::new(db_path)).config(pool_config).runtime(RUNTIME).build().map_err(
-            |e| crate::error::Error::InvalidData {
-                details: format!("Failed to rebuild connection pool: {e}"),
-            },
-        )?;
-
-    let write_conn = pool.get().await?;
-    // Re-apply runtime config (WAL mode, busy timeout, etc.)
-    write_conn.apply_runtime_config(runtime_config).await?;
-
-    *guard = Some(SqliteConnections { pool, write_connection: Arc::new(Mutex::new(write_conn)) });
-
-    Ok(())
-}
+#[cfg(target_family = "wasm")]
+pub use wasm::*;
+#[cfg(target_family = "wasm")]
+pub(crate) use wasm::{SqliteConnections, close_connections, reopen_connections};

--- a/crates/matrix-sdk-sqlite/src/crypto_store.rs
+++ b/crates/matrix-sdk-sqlite/src/crypto_store.rs
@@ -12,15 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(not(target_family = "wasm"))]
+use std::path::PathBuf;
 use std::{
     collections::HashMap,
     fmt,
     ops::Deref,
-    path::{Path, PathBuf},
+    path::Path,
     sync::{Arc, RwLock},
 };
 
 use async_trait::async_trait;
+#[cfg(not(target_family = "wasm"))]
 use deadpool::managed::PoolConfig;
 use matrix_sdk_base::cross_process_lock::CrossProcessLockGeneration;
 use matrix_sdk_crypto::{
@@ -44,17 +47,16 @@ use ruma::{
     events::secret::request::SecretName,
 };
 use rusqlite::{OptionalExtension, named_params, params_from_iter};
-use tokio::{
-    fs,
-    sync::{Mutex, OwnedMutexGuard},
-};
+#[cfg(not(target_family = "wasm"))]
+use tokio::fs;
+use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::{debug, instrument, warn};
 use vodozemac::Curve25519PublicKey;
 use zeroize::Zeroizing;
 
 use crate::{
     OpenStoreError, RuntimeConfig, Secret, SqliteStoreConfig,
-    connection::{self, Connection as SqliteAsyncConn, Pool as SqlitePool, SqliteConnections},
+    connection::{self, Connection as SqliteAsyncConn, SqliteConnections},
     error::{Error, Result},
     utils::{
         EncryptableStore, Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
@@ -74,9 +76,15 @@ pub struct SqliteCryptoStore {
     /// The outer `Mutex` serialises close/reopen with connection access.
     connections: Arc<Mutex<Option<SqliteConnections>>>,
 
+    #[cfg(not(target_family = "wasm"))]
     /// Retained so we can rebuild the pool on reopen.
     db_path: PathBuf,
 
+    #[cfg(target_family = "wasm")]
+    /// Retained so we can rebuild the connection on reopen.
+    db_name: String,
+
+    #[cfg(not(target_family = "wasm"))]
     /// Retained so we can rebuild the pool on reopen.
     pool_config: PoolConfig,
 
@@ -102,6 +110,7 @@ impl EncryptableStore for SqliteCryptoStore {
 }
 
 impl SqliteCryptoStore {
+    #[cfg(not(target_family = "wasm"))]
     /// Create an `SqliteCryptoStore` struct without trying to create the
     /// database or migrate to a newer version.  This is only for use
     /// internally, and for testing.
@@ -115,7 +124,7 @@ impl SqliteCryptoStore {
     /// * `conn` - The connection to use for writing to the store.
     pub(crate) async fn create_raw(
         secret: Option<Secret>,
-        pool: SqlitePool,
+        pool: connection::Pool,
         conn: SqliteAsyncConn,
         pool_config: PoolConfig,
         runtime_config: RuntimeConfig,
@@ -159,6 +168,7 @@ impl SqliteCryptoStore {
         Self::open_with_config(&SqliteStoreConfig::new(path).key(key)).await
     }
 
+    #[cfg(not(target_family = "wasm"))]
     /// Open the SQLite-based crypto store with the config open config.
     pub async fn open_with_config(config: &SqliteStoreConfig) -> Result<Self, OpenStoreError> {
         fs::create_dir_all(&config.path).await.map_err(OpenStoreError::CreateDir)?;
@@ -174,10 +184,25 @@ impl SqliteCryptoStore {
         Ok(this)
     }
 
+    #[cfg(target_family = "wasm")]
+    /// Open the SQLite-based crypto store with the config open config.
+    pub async fn open_with_config(config: &SqliteStoreConfig) -> Result<Self, OpenStoreError> {
+        let runtime_config = config.runtime_config();
+        let conn = config.build_wasm_connection(DATABASE_NAME).await?;
+        let db_name = format!("{}-{}", config.db_name, DATABASE_NAME);
+
+        let this = Self::open_with_connection(conn, config.secret.clone(), db_name, runtime_config)
+            .await?;
+        this.read().await?.apply_runtime_config(runtime_config).await?;
+
+        Ok(this)
+    }
+
+    #[cfg(not(target_family = "wasm"))]
     /// Create an SQLite-based crypto store using the given SQLite database
     /// pool. The given secret will be used to encrypt private data.
     async fn open_with_pool(
-        pool: SqlitePool,
+        pool: connection::Pool,
         secret: Option<Secret>,
         pool_config: PoolConfig,
         runtime_config: RuntimeConfig,
@@ -190,6 +215,40 @@ impl SqliteCryptoStore {
         let version = initialize_store(&conn, version).await?;
 
         let store = Self::create_raw(secret, pool, conn, pool_config, runtime_config).await?;
+
+        run_migrations(&store, version, None).await?;
+
+        store.write().await?.wal_checkpoint().await;
+
+        Ok(store)
+    }
+
+    #[cfg(target_family = "wasm")]
+    /// Create an SQLite-based crypto store using a single WASM connection.
+    async fn open_with_connection(
+        conn: SqliteAsyncConn,
+        secret: Option<Secret>,
+        db_name: String,
+        runtime_config: RuntimeConfig,
+    ) -> Result<Self, OpenStoreError> {
+        let version = conn.db_version().await?;
+        debug!("Opened sqlite store with version {}", version);
+
+        let version = initialize_store(&conn, version).await?;
+
+        let store_cipher = match secret {
+            Some(s) => Some(Arc::new(conn.get_or_create_store_cipher(s).await?)),
+            None => None,
+        };
+
+        let store = Self {
+            store_cipher,
+            connections: Arc::new(Mutex::new(Some(SqliteConnections::new(conn)))),
+            db_name,
+            runtime_config,
+            static_account: Arc::new(RwLock::new(None)),
+            save_changes_lock: Default::default(),
+        };
 
         run_migrations(&store, version, None).await?;
 
@@ -226,6 +285,7 @@ impl SqliteCryptoStore {
         self.static_account.read().unwrap().clone()
     }
 
+    #[cfg(not(target_family = "wasm"))]
     /// Acquire a connection for executing read operations.
     #[instrument(skip_all)]
     async fn read(&self) -> Result<SqliteAsyncConn> {
@@ -235,6 +295,15 @@ impl SqliteCryptoStore {
             conns.pool.clone()
         };
         Ok(pool.get().await?)
+    }
+
+    #[cfg(target_family = "wasm")]
+    /// Acquire a connection for executing read operations.
+    #[instrument(skip_all)]
+    async fn read(&self) -> Result<SqliteAsyncConn> {
+        let guard = self.connections.lock().await;
+        let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
+        Ok(conns.conn.clone())
     }
 
     /// Acquire a connection for executing write operations.
@@ -737,7 +806,8 @@ impl SqliteConnectionExt for rusqlite::Connection {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
     async fn get_sessions_for_sender_key(&self, sender_key: Key) -> Result<Vec<Vec<u8>>> {
         Ok(self
@@ -1071,10 +1141,16 @@ trait SqliteObjectCryptoStoreExt: SqliteAsyncConnExt {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 #[async_trait]
 impl SqliteObjectCryptoStoreExt for SqliteAsyncConn {}
 
-#[async_trait]
+#[cfg(target_family = "wasm")]
+#[async_trait(?Send)]
+impl SqliteObjectCryptoStoreExt for SqliteAsyncConn {}
+
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl CryptoStore for SqliteCryptoStore {
     type Error = Error;
 
@@ -1776,11 +1852,7 @@ impl CryptoStore for SqliteCryptoStore {
 
     async fn remove_custom_value(&self, key: &str) -> Result<()> {
         let key = key.to_owned();
-        self.write()
-            .await?
-            .interact(move |conn| conn.execute("DELETE FROM kv WHERE key = ?1", (&key,)))
-            .await
-            .unwrap()?;
+        self.write().await?.execute("DELETE FROM kv WHERE key = ?1", (key,)).await?;
         Ok(())
     }
 
@@ -1846,13 +1918,21 @@ impl CryptoStore for SqliteCryptoStore {
     }
 
     async fn reopen(&self) -> Result<()> {
-        connection::reopen_connections(
-            &self.connections,
-            self.db_path.clone(),
-            self.pool_config,
-            self.runtime_config,
-        )
-        .await?;
+        #[cfg(not(target_family = "wasm"))]
+        {
+            connection::reopen_connections(
+                &self.connections,
+                self.db_path.clone(),
+                self.pool_config,
+                self.runtime_config,
+            )
+            .await?;
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            connection::reopen_connections(&self.connections, &self.db_name, self.runtime_config)
+                .await?;
+        }
         Ok(())
     }
 
@@ -1861,7 +1941,7 @@ impl CryptoStore for SqliteCryptoStore {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::{path::Path, sync::LazyLock};
 
@@ -2364,7 +2444,7 @@ mod tests {
     cryptostore_integration_tests_time!();
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod encrypted_tests {
     use std::sync::LazyLock;
 
@@ -2397,7 +2477,7 @@ mod encrypted_tests {
     cryptostore_integration_tests_time!();
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod close_reopen_tests {
     use std::sync::LazyLock;
 

--- a/crates/matrix-sdk-sqlite/src/error.rs
+++ b/crates/matrix-sdk-sqlite/src/error.rs
@@ -24,21 +24,22 @@ use matrix_sdk_base::store::StoreError as StateStoreError;
 #[cfg(feature = "crypto-store")]
 use matrix_sdk_crypto::CryptoStoreError;
 use thiserror::Error;
-use tokio::io;
 
-use crate::connection::{CreatePoolError, PoolError};
+use crate::connection::{AcquireConnectionError, OpenConnectionError};
 
 /// All the errors that can occur when opening an SQLite store.
 #[derive(Error, Debug)]
 #[non_exhaustive]
 pub enum OpenStoreError {
     /// Failed to create the DB's parent directory.
+    #[cfg(not(target_family = "wasm"))]
     #[error("Failed to create the database's parent directory: {0}")]
-    CreateDir(#[source] io::Error),
+    CreateDir(#[source] tokio::io::Error),
 
-    /// Failed to create the DB pool.
+    /// Failed to open the DB connections (natively: create the connection
+    /// pool).
     #[error(transparent)]
-    CreatePool(#[from] CreatePoolError),
+    CreatePool(#[from] OpenConnectionError),
 
     /// Failed to load the database's version.
     #[error("Failed to load database version: {0}")]
@@ -56,9 +57,9 @@ pub enum OpenStoreError {
     #[error("Failed to run migrations: {0}")]
     Migration(#[from] Error),
 
-    /// Failed to get a DB connection from the pool.
+    /// Failed to acquire a DB connection (natively: from the pool).
     #[error(transparent)]
-    Pool(#[from] PoolError),
+    Pool(#[from] AcquireConnectionError),
 
     /// Failed to initialize the store cipher.
     #[error("Failed to initialize the store cipher: {0}")]
@@ -82,7 +83,7 @@ pub enum Error {
     SqliteMaximumVariableNumber(i32),
 
     #[error(transparent)]
-    Pool(PoolError),
+    Pool(AcquireConnectionError),
 
     #[error(transparent)]
     Encode(rmp_serde::encode::Error),
@@ -144,7 +145,7 @@ impl From<rusqlite::Error> for Error {
     }
 }
 
-impl_from!(PoolError => Error::Pool);
+impl_from!(AcquireConnectionError => Error::Pool);
 impl_from!(rmp_serde::encode::Error => Error::Encode);
 impl_from!(rmp_serde::decode::Error => Error::Decode);
 impl_from!(matrix_sdk_store_encryption::Error => Error::Encryption);

--- a/crates/matrix-sdk-sqlite/src/event_cache_store.rs
+++ b/crates/matrix-sdk-sqlite/src/event_cache_store.rs
@@ -14,15 +14,12 @@
 
 //! An SQLite-based backend for the [`EventCacheStore`].
 
-use std::{
-    collections::HashMap,
-    fmt,
-    iter::once,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+#[cfg(not(target_family = "wasm"))]
+use std::path::PathBuf;
+use std::{collections::HashMap, fmt, iter::once, path::Path, sync::Arc};
 
 use async_trait::async_trait;
+#[cfg(not(target_family = "wasm"))]
 use deadpool::managed::PoolConfig;
 use matrix_sdk_base::{
     cross_process_lock::CrossProcessLockGeneration,
@@ -44,15 +41,14 @@ use ruma::{
 use rusqlite::{
     OptionalExtension, ToSql, Transaction, TransactionBehavior, params, params_from_iter,
 };
-use tokio::{
-    fs,
-    sync::{Mutex, OwnedMutexGuard},
-};
+#[cfg(not(target_family = "wasm"))]
+use tokio::fs;
+use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::{debug, error, instrument, trace};
 
 use crate::{
     OpenStoreError, RuntimeConfig, Secret, SqliteStoreConfig,
-    connection::{self, Connection as SqliteAsyncConn, Pool as SqlitePool, SqliteConnections},
+    connection::{self, Connection as SqliteAsyncConn, SqliteConnections},
     error::{Error, Result},
     utils::{
         EncryptableStore, Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
@@ -84,9 +80,15 @@ pub struct SqliteEventCacheStore {
     /// `Some` when active, `None` when closed.
     connections: Arc<Mutex<Option<SqliteConnections>>>,
 
+    #[cfg(not(target_family = "wasm"))]
     /// Retained so we can rebuild the pool on reopen.
     db_path: PathBuf,
 
+    #[cfg(target_family = "wasm")]
+    /// Retained so we can rebuild the connection on reopen.
+    db_name: String,
+
+    #[cfg(not(target_family = "wasm"))]
     /// Retained so we can rebuild the pool on reopen.
     pool_config: PoolConfig,
 
@@ -126,6 +128,7 @@ impl SqliteEventCacheStore {
         Self::open_with_config(&SqliteStoreConfig::new(path).key(key)).await
     }
 
+    #[cfg(not(target_family = "wasm"))]
     /// Open the SQLite-based event cache store with the config open config.
     #[instrument(skip(config), fields(path = ?config.path))]
     pub async fn open_with_config(config: &SqliteStoreConfig) -> Result<Self, OpenStoreError> {
@@ -151,10 +154,27 @@ impl SqliteEventCacheStore {
         Ok(this)
     }
 
+    #[cfg(target_family = "wasm")]
+    /// Open the SQLite-based event cache store with the config open config.
+    pub async fn open_with_config(config: &SqliteStoreConfig) -> Result<Self, OpenStoreError> {
+        let runtime_config = config.runtime_config();
+        let conn = config.build_wasm_connection(DATABASE_NAME).await?;
+        let db_name = format!("{}-{}", config.db_name, DATABASE_NAME);
+
+        let this = Self::open_with_connection(conn, config.secret.clone(), db_name, runtime_config)
+            .await?;
+
+        // Apply runtime config on the write connection.
+        this.write().await?.apply_runtime_config(runtime_config).await?;
+
+        Ok(this)
+    }
+
+    #[cfg(not(target_family = "wasm"))]
     /// Open an SQLite-based event cache store using the given SQLite database
     /// pool. The given secret will be used to encrypt private data.
     async fn open_with_pool(
-        pool: SqlitePool,
+        pool: connection::Pool,
         db_path: PathBuf,
         pool_config: PoolConfig,
         runtime_config: RuntimeConfig,
@@ -188,7 +208,35 @@ impl SqliteEventCacheStore {
         })
     }
 
+    #[cfg(target_family = "wasm")]
+    /// Create an SQLite-based event cache store using a single WASM connection.
+    async fn open_with_connection(
+        conn: SqliteAsyncConn,
+        secret: Option<Secret>,
+        db_name: String,
+        runtime_config: RuntimeConfig,
+    ) -> Result<Self, OpenStoreError> {
+        let version = conn.db_version().await?;
+
+        run_migrations(&conn, version).await?;
+
+        conn.wal_checkpoint().await;
+
+        let store_cipher = match secret {
+            Some(s) => Some(Arc::new(conn.get_or_create_store_cipher(s).await?)),
+            None => None,
+        };
+
+        Ok(Self {
+            store_cipher,
+            connections: Arc::new(Mutex::new(Some(SqliteConnections::new(conn)))),
+            db_name,
+            runtime_config,
+        })
+    }
+
     /// Acquire a connection for executing read operations.
+    #[cfg(not(target_family = "wasm"))]
     #[instrument(skip_all)]
     async fn read(&self) -> Result<SqliteAsyncConn> {
         let pool = {
@@ -206,6 +254,15 @@ impl SqliteEventCacheStore {
         connection.execute_batch("PRAGMA foreign_keys = ON;").await?;
 
         Ok(connection)
+    }
+
+    /// Acquire a connection for executing read operations.
+    #[cfg(target_family = "wasm")]
+    #[instrument(skip_all)]
+    async fn read(&self) -> Result<SqliteAsyncConn> {
+        let guard = self.connections.lock().await;
+        let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
+        Ok(conns.conn.clone())
     }
 
     /// Acquire a connection for executing write operations.
@@ -266,12 +323,8 @@ impl SqliteEventCacheStore {
     }
 
     async fn get_db_size(&self) -> Result<Option<usize>> {
-        let pool = {
-            let guard = self.connections.lock().await;
-            let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
-            conns.pool.clone()
-        };
-        Ok(Some(pool.get().await?.get_db_size().await?))
+        let read_conn = self.read().await?;
+        Ok(Some(read_conn.get_db_size().await?))
     }
 
     pub async fn close(&self) -> Result<()> {
@@ -280,18 +333,26 @@ impl SqliteEventCacheStore {
     }
 
     pub async fn reopen(&self) -> Result<()> {
-        connection::reopen_connections(
-            &self.connections,
-            self.db_path.clone(),
-            self.pool_config,
-            self.runtime_config,
-        )
-        .await?;
+        #[cfg(not(target_family = "wasm"))]
+        {
+            connection::reopen_connections(
+                &self.connections,
+                self.db_path.clone(),
+                self.pool_config,
+                self.runtime_config,
+            )
+            .await?;
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            connection::reopen_connections(&self.connections, &self.db_name, self.runtime_config)
+                .await?;
+        }
         Ok(())
     }
 
     /// Returns the pool size status, for testing purposes.
-    #[cfg(test)]
+    #[cfg(all(test, not(target_family = "wasm")))]
     async fn pool_max_size(&self) -> Option<usize> {
         let guard = self.connections.lock().await;
         guard.as_ref().map(|conns| conns.pool.status().max_size)
@@ -581,7 +642,8 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     Ok(())
 }
 
-#[async_trait]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl EventCacheStore for SqliteEventCacheStore {
     type Error = Error;
 
@@ -1633,6 +1695,7 @@ fn find_event_relations_transaction(
 /// transaction in immediate (write) mode from the beginning, precluding errors
 /// of the kind SQLITE_BUSY from happening, for transactions that may involve
 /// both reads and writes, and start with a write.
+#[cfg(not(target_family = "wasm"))]
 async fn with_immediate_transaction<
     T: Send + 'static,
     F: FnOnce(&Transaction<'_>) -> Result<T, Error> + Send + 'static,
@@ -1666,6 +1729,32 @@ async fn with_immediate_transaction<
         .await
         // SAFETY: same logic as in [`deadpool::managed::Object::with_transaction`].`
         .unwrap()
+}
+
+#[cfg(target_family = "wasm")]
+async fn with_immediate_transaction<
+    T: 'static,
+    F: FnOnce(&Transaction<'_>) -> Result<T, Error> + 'static,
+>(
+    this: &SqliteEventCacheStore,
+    f: F,
+) -> Result<T, Error> {
+    this.write().await?.interact(move |conn| -> Result<T, Error> {
+        conn.set_transaction_behavior(TransactionBehavior::Immediate);
+
+        let code = || -> Result<T, Error> {
+            let txn = conn.transaction()?;
+            let res = f(&txn)?;
+            txn.commit()?;
+            Ok(res)
+        };
+
+        let res = code();
+
+        conn.set_transaction_behavior(TransactionBehavior::Deferred);
+
+        res
+    })
 }
 
 fn insert_chunk(
@@ -1724,7 +1813,7 @@ fn insert_chunk(
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::{
         path::PathBuf,
@@ -1909,7 +1998,7 @@ mod tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod encrypted_tests {
     use std::sync::{
         LazyLock,
@@ -2014,7 +2103,7 @@ mod encrypted_tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod close_reopen_tests {
     use std::sync::{
         LazyLock,

--- a/crates/matrix-sdk-sqlite/src/lib.rs
+++ b/crates/matrix-sdk-sqlite/src/lib.rs
@@ -28,12 +28,17 @@ mod media_store;
 #[cfg(feature = "state-store")]
 mod state_store;
 mod utils;
+
+use std::fmt;
+#[cfg(target_family = "wasm")]
+use std::path::Path;
+#[cfg(not(target_family = "wasm"))]
 use std::{
     cmp::max,
-    fmt,
     path::{Path, PathBuf},
 };
 
+#[cfg(not(target_family = "wasm"))]
 use deadpool::managed::PoolConfig;
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
@@ -47,7 +52,7 @@ pub use self::media_store::SqliteMediaStore;
 #[cfg(feature = "state-store")]
 pub use self::state_store::{DATABASE_NAME as STATE_STORE_DATABASE_NAME, SqliteStateStore};
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 matrix_sdk_test_utils::init_tracing_for_tests!();
 
 /// An enum used to store the secret that gives access to a store
@@ -59,7 +64,12 @@ pub enum Secret {
     PassPhrase(Zeroizing<String>),
 }
 
+// ===========================================================================
+// Native SqliteStoreConfig — connection pool based
+// ===========================================================================
+
 /// A configuration structure used for opening a store.
+#[cfg(not(target_family = "wasm"))]
 #[derive(Clone)]
 pub struct SqliteStoreConfig {
     /// Path to the database, without the file name.
@@ -72,6 +82,7 @@ pub struct SqliteStoreConfig {
     runtime_config: RuntimeConfig,
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl fmt::Debug for SqliteStoreConfig {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
@@ -85,10 +96,12 @@ impl fmt::Debug for SqliteStoreConfig {
 
 /// The minimum size of the connections pool.
 ///
-/// We need at least 2 connections: one connection for write operations, and one
+/// We need at least 2 connections: one connection for write operations, and one
 /// connection for read operations.
+#[cfg(not(target_family = "wasm"))]
 const POOL_MINIMUM_SIZE: usize = 2;
 
+#[cfg(not(target_family = "wasm"))]
 impl SqliteStoreConfig {
     /// Create a new [`SqliteStoreConfig`] with a path representing the
     /// directory containing the store database.
@@ -234,6 +247,147 @@ impl SqliteStoreConfig {
     }
 }
 
+// ===========================================================================
+// WASM SqliteStoreConfig — single connection, OPFS-backed
+// ===========================================================================
+
+/// A configuration structure used for opening a store.
+///
+/// # WASM specifics
+///
+/// On the `wasm32-unknown-unknown` target, the stores are backed by SQLite
+/// databases living in the [Origin Private File System] (OPFS). This comes
+/// with constraints that the embedding application must uphold:
+///
+/// - **Single dedicated Web Worker.** All stores must be created and used from
+///   one dedicated Web Worker. OPFS synchronous access handles are unavailable
+///   on the main thread, and the connection wrapper panics when accessed from a
+///   thread other than the one that created it.
+/// - **No concurrent tabs.** OPFS synchronous access handles are exclusive per
+///   agent. A second tab or worker opening the same stores will fail with an
+///   `OpenStoreError`. Coordinate access at the application level, e.g. with a
+///   `SharedWorker` or the [Web Locks API].
+/// - **Queries run synchronously.** Unlike the native backend, which executes
+///   queries on blocking threads, queries on WASM run inline and block the
+///   worker's event loop until they complete.
+/// - **The path is a name prefix.** OPFS has no filesystem hierarchy; the
+///   `path` passed to [`SqliteStoreConfig::new`] is used as a plain prefix for
+///   the database names.
+///
+/// [Origin Private File System]: https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system
+/// [Web Locks API]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API
+#[cfg(target_family = "wasm")]
+#[derive(Clone)]
+pub struct SqliteStoreConfig {
+    /// Database name prefix (OPFS has no filesystem hierarchy).
+    db_name: String,
+    /// Secret to open the store, if any.
+    secret: Option<Secret>,
+    /// The runtime configuration to apply when opening an SQLite connection.
+    runtime_config: RuntimeConfig,
+}
+
+#[cfg(target_family = "wasm")]
+impl fmt::Debug for SqliteStoreConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SqliteStoreConfig")
+            .field("db_name", &self.db_name)
+            .field("runtime_config", &self.runtime_config)
+            .finish_non_exhaustive()
+    }
+}
+
+#[cfg(target_family = "wasm")]
+impl SqliteStoreConfig {
+    /// Create a new [`SqliteStoreConfig`].
+    ///
+    /// On WASM, `path` is used as a database name prefix (OPFS has no
+    /// filesystem hierarchy).
+    pub fn new<P>(path: P) -> Self
+    where
+        P: AsRef<Path>,
+    {
+        Self {
+            db_name: path.as_ref().to_string_lossy().into_owned(),
+            runtime_config: RuntimeConfig::default(),
+            secret: None,
+        }
+    }
+
+    /// Similar to [`SqliteStoreConfig::new`], but with defaults tailored for a
+    /// low memory usage environment.
+    pub fn with_low_memory_config<P>(path: P) -> Self
+    where
+        P: AsRef<Path>,
+    {
+        let mut s = Self::new(path);
+        s.runtime_config.cache_size = 500_000;
+        s.runtime_config.journal_size_limit = 2_000_000;
+        s
+    }
+
+    /// Override the database name prefix.
+    pub fn path<P>(mut self, path: P) -> Self
+    where
+        P: AsRef<Path>,
+    {
+        self.db_name = path.as_ref().to_string_lossy().into_owned();
+        self
+    }
+
+    /// Define the passphrase if the store is encoded.
+    pub fn passphrase(mut self, passphrase: Option<&str>) -> Self {
+        self.secret =
+            passphrase.map(|passphrase| Secret::PassPhrase(Zeroizing::new(passphrase.to_owned())));
+        self
+    }
+
+    /// Define the key if the store is encoded.
+    pub fn key(mut self, key: Option<&[u8; 32]>) -> Self {
+        self.secret = key.map(|key| Secret::Key(Box::new(*key)));
+        self
+    }
+
+    /// Optimize the database. See [`PRAGMA optimize`].
+    ///
+    /// [`PRAGMA optimize`]: https://www.sqlite.org/pragma.html#pragma_optimize
+    pub fn optimize(mut self, optimize: bool) -> Self {
+        self.runtime_config.optimize = optimize;
+        self
+    }
+
+    /// Define the maximum size in **bytes** the SQLite cache can use.
+    pub fn cache_size(mut self, cache_size: u32) -> Self {
+        self.runtime_config.cache_size = cache_size;
+        self
+    }
+
+    /// Limit the size of the WAL file, in **bytes**.
+    pub fn journal_size_limit(mut self, limit: u32) -> Self {
+        self.runtime_config.journal_size_limit = limit;
+        self
+    }
+
+    /// Returns the runtime configuration.
+    pub(crate) fn runtime_config(&self) -> RuntimeConfig {
+        self.runtime_config
+    }
+
+    /// Build a single WASM connection for a given database.
+    pub(crate) async fn build_wasm_connection(
+        &self,
+        database_name: &str,
+    ) -> Result<connection::Connection, connection::OpenConnectionError> {
+        let full_name = format!("{}-{}", self.db_name, database_name);
+        connection::open_wasm_connection(&full_name).await
+    }
+}
+
+// ===========================================================================
+// Shared types
+// ===========================================================================
+
 /// This type represents values to set at runtime when a database is opened.
 ///
 /// This configuration is applied by
@@ -266,15 +420,18 @@ impl Default for RuntimeConfig {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::{
         ops::Not,
         path::{Path, PathBuf},
     };
 
-    use super::{POOL_MINIMUM_SIZE, Secret, SqliteStoreConfig};
+    #[cfg(not(target_family = "wasm"))]
+    use super::POOL_MINIMUM_SIZE;
+    use super::{Secret, SqliteStoreConfig};
 
+    #[cfg(not(target_family = "wasm"))]
     #[test]
     fn test_new() {
         let store_config = SqliteStoreConfig::new(Path::new("foo"));
@@ -285,6 +442,7 @@ mod tests {
         assert_eq!(store_config.runtime_config.journal_size_limit, 10_000_000);
     }
 
+    #[cfg(not(target_family = "wasm"))]
     #[test]
     fn test_with_low_memory_config() {
         let store_config = SqliteStoreConfig::with_low_memory_config(Path::new("foo"));
@@ -295,6 +453,7 @@ mod tests {
         assert_eq!(store_config.runtime_config.journal_size_limit, 2_000_000);
     }
 
+    #[cfg(not(target_family = "wasm"))]
     #[test]
     fn test_store_config_when_passphrase() {
         let store_config = SqliteStoreConfig::new(Path::new("foo"))
@@ -312,6 +471,7 @@ mod tests {
         assert_eq!(store_config.runtime_config.journal_size_limit, 44);
     }
 
+    #[cfg(not(target_family = "wasm"))]
     #[test]
     fn test_store_config_when_key() {
         let store_config = SqliteStoreConfig::new(Path::new("foo"))
@@ -338,17 +498,17 @@ mod tests {
         assert_eq!(store_config.runtime_config.journal_size_limit, 44);
     }
 
+    #[cfg(not(target_family = "wasm"))]
     #[test]
     fn test_store_config_path() {
         let store_config = SqliteStoreConfig::new(Path::new("foo")).path(Path::new("bar"));
-
         assert_eq!(store_config.path, PathBuf::from("bar"));
     }
 
+    #[cfg(not(target_family = "wasm"))]
     #[test]
     fn test_pool_size_has_a_minimum() {
         let store_config = SqliteStoreConfig::new(Path::new("foo")).pool_max_size(1);
-
         assert_eq!(store_config.pool_config.max_size, POOL_MINIMUM_SIZE);
     }
 }

--- a/crates/matrix-sdk-sqlite/src/media_store.rs
+++ b/crates/matrix-sdk-sqlite/src/media_store.rs
@@ -14,13 +14,12 @@
 
 //! An SQLite-based backend for the [`MediaStore`].
 
-use std::{
-    fmt,
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+#[cfg(not(target_family = "wasm"))]
+use std::path::PathBuf;
+use std::{fmt, path::Path, sync::Arc};
 
 use async_trait::async_trait;
+#[cfg(not(target_family = "wasm"))]
 use deadpool::managed::PoolConfig;
 use matrix_sdk_base::{
     cross_process_lock::CrossProcessLockGeneration,
@@ -36,15 +35,14 @@ use matrix_sdk_base::{
 use matrix_sdk_store_encryption::StoreCipher;
 use ruma::{MilliSecondsSinceUnixEpoch, MxcUri, time::SystemTime};
 use rusqlite::{OptionalExtension, params_from_iter};
-use tokio::{
-    fs,
-    sync::{Mutex, OwnedMutexGuard},
-};
+#[cfg(not(target_family = "wasm"))]
+use tokio::fs;
+use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::{debug, instrument};
 
 use crate::{
     OpenStoreError, RuntimeConfig, Secret, SqliteStoreConfig,
-    connection::{self, Connection as SqliteAsyncConn, Pool as SqlitePool, SqliteConnections},
+    connection::{self, Connection as SqliteAsyncConn, SqliteConnections},
     error::{Error, Result},
     utils::{
         EncryptableStore, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
@@ -72,9 +70,15 @@ pub struct SqliteMediaStore {
     /// `Some` when active, `None` when closed.
     connections: Arc<Mutex<Option<SqliteConnections>>>,
 
+    #[cfg(not(target_family = "wasm"))]
     /// Retained so we can rebuild the pool on reopen.
     db_path: PathBuf,
 
+    #[cfg(target_family = "wasm")]
+    /// Retained so we can rebuild the connection on reopen.
+    db_name: String,
+
+    #[cfg(not(target_family = "wasm"))]
     /// Retained so we can rebuild the pool on reopen.
     pool_config: PoolConfig,
 
@@ -116,6 +120,7 @@ impl SqliteMediaStore {
         Self::open_with_config(&SqliteStoreConfig::new(path).key(key)).await
     }
 
+    #[cfg(not(target_family = "wasm"))]
     /// Open the SQLite-based media store with the config open config.
     #[instrument(skip(config), fields(path = ?config.path))]
     pub async fn open_with_config(config: &SqliteStoreConfig) -> Result<Self, OpenStoreError> {
@@ -141,10 +146,27 @@ impl SqliteMediaStore {
         Ok(this)
     }
 
+    #[cfg(target_family = "wasm")]
+    /// Open the SQLite-based media store with the config open config.
+    pub async fn open_with_config(config: &SqliteStoreConfig) -> Result<Self, OpenStoreError> {
+        let runtime_config = config.runtime_config();
+        let conn = config.build_wasm_connection(DATABASE_NAME).await?;
+        let db_name = format!("{}-{}", config.db_name, DATABASE_NAME);
+
+        let this = Self::open_with_connection(conn, config.secret.clone(), db_name, runtime_config)
+            .await?;
+
+        // Apply runtime config on the write connection.
+        this.write().await?.apply_runtime_config(runtime_config).await?;
+
+        Ok(this)
+    }
+
+    #[cfg(not(target_family = "wasm"))]
     /// Open an SQLite-based media store using the given SQLite database
     /// pool. The given passphrase will be used to encrypt private data.
     async fn open_with_pool(
-        pool: SqlitePool,
+        pool: connection::Pool,
         db_path: PathBuf,
         pool_config: PoolConfig,
         runtime_config: RuntimeConfig,
@@ -183,7 +205,40 @@ impl SqliteMediaStore {
         })
     }
 
+    #[cfg(target_family = "wasm")]
+    /// Create an SQLite-based media store using a single WASM connection.
+    async fn open_with_connection(
+        conn: SqliteAsyncConn,
+        secret: Option<Secret>,
+        db_name: String,
+        runtime_config: RuntimeConfig,
+    ) -> Result<Self, OpenStoreError> {
+        let version = conn.db_version().await?;
+        run_migrations(&conn, version).await?;
+
+        conn.wal_checkpoint().await;
+
+        let store_cipher = match &secret {
+            Some(s) => Some(Arc::new(conn.get_or_create_store_cipher(s.clone()).await?)),
+            None => None,
+        };
+
+        let media_service = MediaService::new();
+        let media_retention_policy = conn.get_serialized_kv(keys::MEDIA_RETENTION_POLICY).await?;
+        let last_media_cleanup_time = conn.get_serialized_kv(keys::LAST_MEDIA_CLEANUP_TIME).await?;
+        media_service.restore(media_retention_policy, last_media_cleanup_time);
+
+        Ok(Self {
+            store_cipher,
+            connections: Arc::new(Mutex::new(Some(SqliteConnections::new(conn)))),
+            db_name,
+            runtime_config,
+            media_service,
+        })
+    }
+
     // Acquire a connection for executing read operations.
+    #[cfg(not(target_family = "wasm"))]
     #[instrument(skip_all)]
     async fn read(&self) -> Result<SqliteAsyncConn> {
         let pool = {
@@ -201,6 +256,14 @@ impl SqliteMediaStore {
         connection.execute_batch("PRAGMA foreign_keys = ON;").await?;
 
         Ok(connection)
+    }
+
+    #[cfg(target_family = "wasm")]
+    #[instrument(skip_all)]
+    async fn read(&self) -> Result<SqliteAsyncConn> {
+        let guard = self.connections.lock().await;
+        let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
+        Ok(conns.conn.clone())
     }
 
     // Acquire a connection for executing write operations.
@@ -233,12 +296,8 @@ impl SqliteMediaStore {
     }
 
     async fn get_db_size(&self) -> Result<Option<usize>> {
-        let pool = {
-            let guard = self.connections.lock().await;
-            let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
-            conns.pool.clone()
-        };
-        Ok(Some(pool.get().await?.get_db_size().await?))
+        let read_conn = self.read().await?;
+        Ok(Some(read_conn.get_db_size().await?))
     }
 
     pub async fn close(&self) -> Result<()> {
@@ -247,18 +306,26 @@ impl SqliteMediaStore {
     }
 
     pub async fn reopen(&self) -> Result<()> {
-        connection::reopen_connections(
-            &self.connections,
-            self.db_path.clone(),
-            self.pool_config,
-            self.runtime_config,
-        )
-        .await?;
+        #[cfg(not(target_family = "wasm"))]
+        {
+            connection::reopen_connections(
+                &self.connections,
+                self.db_path.clone(),
+                self.pool_config,
+                self.runtime_config,
+            )
+            .await?;
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            connection::reopen_connections(&self.connections, &self.db_name, self.runtime_config)
+                .await?;
+        }
         Ok(())
     }
 
     /// Returns the pool size status, for testing purposes.
-    #[cfg(test)]
+    #[cfg(all(test, not(target_family = "wasm")))]
     async fn pool_max_size(&self) -> Option<usize> {
         let guard = self.connections.lock().await;
         guard.as_ref().map(|conns| conns.pool.status().max_size)
@@ -296,7 +363,8 @@ async fn run_migrations(conn: &SqliteAsyncConn, version: u8) -> Result<()> {
     Ok(())
 }
 
-#[async_trait]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl MediaStore for SqliteMediaStore {
     type Error = Error;
 
@@ -738,7 +806,7 @@ impl MediaStoreInner for SqliteMediaStore {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::{
         path::PathBuf,
@@ -872,7 +940,7 @@ mod tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod close_reopen_tests {
     use std::sync::{
         LazyLock,
@@ -1109,7 +1177,7 @@ mod close_reopen_tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod encrypted_tests {
     use std::sync::{
         LazyLock,

--- a/crates/matrix-sdk-sqlite/src/state_store.rs
+++ b/crates/matrix-sdk-sqlite/src/state_store.rs
@@ -1,13 +1,16 @@
+#[cfg(not(target_family = "wasm"))]
+use std::path::PathBuf;
 use std::{
     borrow::Cow,
     collections::{BTreeMap, BTreeSet, HashMap},
     fmt, iter,
-    path::{Path, PathBuf},
+    path::Path,
     str::FromStr as _,
     sync::Arc,
 };
 
 use async_trait::async_trait;
+#[cfg(not(target_family = "wasm"))]
 use deadpool::managed::PoolConfig;
 use matrix_sdk_base::{
     MinimalRoomMemberEvent, ROOM_VERSION_FALLBACK, ROOM_VERSION_RULES_FALLBACK, RoomInfo,
@@ -38,15 +41,14 @@ use ruma::{
 };
 use rusqlite::{OptionalExtension, Transaction};
 use serde::{Deserialize, Serialize};
-use tokio::{
-    fs,
-    sync::{Mutex, OwnedMutexGuard},
-};
+#[cfg(not(target_family = "wasm"))]
+use tokio::fs;
+use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::{debug, instrument, warn};
 
 use crate::{
     OpenStoreError, RuntimeConfig, Secret, SqliteStoreConfig,
-    connection::{self, Connection as SqliteAsyncConn, Pool as SqlitePool, SqliteConnections},
+    connection::{self, Connection as SqliteAsyncConn, SqliteConnections},
     error::{Error, Result},
     utils::{
         EncryptableStore, Key, SqliteAsyncConnExt, SqliteKeyValueStoreAsyncConnExt,
@@ -81,9 +83,15 @@ pub struct SqliteStateStore {
     /// `Some` when active, `None` when closed.
     connections: Arc<Mutex<Option<SqliteConnections>>>,
 
+    #[cfg(not(target_family = "wasm"))]
     /// Retained so we can rebuild the pool on reopen.
     db_path: PathBuf,
 
+    #[cfg(target_family = "wasm")]
+    /// Retained so we can rebuild the connection on reopen.
+    db_name: String,
+
+    #[cfg(not(target_family = "wasm"))]
     /// Retained so we can rebuild the pool on reopen.
     pool_config: PoolConfig,
 
@@ -117,13 +125,14 @@ impl SqliteStateStore {
         Self::open_with_config(&SqliteStoreConfig::new(path).key(key)).await
     }
 
+    #[cfg(not(target_family = "wasm"))]
     /// Open the SQLite-based state store with the config open config.
     pub async fn open_with_config(config: &SqliteStoreConfig) -> Result<Self, OpenStoreError> {
         fs::create_dir_all(&config.path).await.map_err(OpenStoreError::CreateDir)?;
 
         let pool = config.build_pool_of_connections(DATABASE_NAME)?;
-        let pool_config = config.pool_config;
-        let runtime_config = config.runtime_config;
+        let pool_config = config.pool_config();
+        let runtime_config = config.runtime_config();
 
         let this =
             Self::open_with_pool(pool, config.secret.clone(), pool_config, runtime_config).await?;
@@ -132,10 +141,24 @@ impl SqliteStateStore {
         Ok(this)
     }
 
+    #[cfg(target_family = "wasm")]
+    /// Open the SQLite-based state store with the config open config.
+    pub async fn open_with_config(config: &SqliteStoreConfig) -> Result<Self, OpenStoreError> {
+        let runtime_config = config.runtime_config();
+        let conn = config.build_wasm_connection(DATABASE_NAME).await?;
+        let db_name = format!("{}-{}", config.db_name, DATABASE_NAME);
+
+        let this = Self::open_with_connection(conn, config.secret.clone(), db_name, runtime_config)
+            .await?;
+        this.read().await?.apply_runtime_config(runtime_config).await?;
+
+        Ok(this)
+    }
+
+    #[cfg(not(target_family = "wasm"))]
     /// Create an SQLite-based state store using the given SQLite database pool.
-    /// The given secret will be used to encrypt private data.
     pub(crate) async fn open_with_pool(
-        pool: SqlitePool,
+        pool: connection::Pool,
         secret: Option<Secret>,
         pool_config: PoolConfig,
         runtime_config: RuntimeConfig,
@@ -162,6 +185,38 @@ impl SqliteStateStore {
             }))),
             db_path,
             pool_config,
+            runtime_config,
+        };
+        this.run_migrations(version, None).await?;
+
+        this.read().await?.wal_checkpoint().await;
+
+        Ok(this)
+    }
+
+    #[cfg(target_family = "wasm")]
+    /// Create an SQLite-based state store using a single WASM connection.
+    pub(crate) async fn open_with_connection(
+        conn: SqliteAsyncConn,
+        secret: Option<Secret>,
+        db_name: String,
+        runtime_config: RuntimeConfig,
+    ) -> Result<Self, OpenStoreError> {
+        let mut version = conn.db_version().await?;
+
+        if version == 0 {
+            init(&conn).await?;
+            version = 1;
+        }
+
+        let store_cipher = match secret {
+            Some(s) => Some(Arc::new(conn.get_or_create_store_cipher(s).await?)),
+            None => None,
+        };
+        let this = Self {
+            store_cipher,
+            connections: Arc::new(Mutex::new(Some(SqliteConnections::new(conn)))),
+            db_name,
             runtime_config,
         };
         this.run_migrations(version, None).await?;
@@ -547,8 +602,7 @@ impl SqliteStateStore {
         self.encode_key(keys::KV_BLOB, full_key)
     }
 
-    /// Acquire a connection for executing read operations.
-    /// Returns `StoreClosed` if closed.
+    #[cfg(not(target_family = "wasm"))]
     #[instrument(skip_all)]
     async fn read(&self) -> Result<SqliteAsyncConn> {
         let pool = {
@@ -559,8 +613,14 @@ impl SqliteStateStore {
         Ok(pool.get().await?)
     }
 
-    /// Acquire a connection for executing write operations.
-    /// Returns `StoreClosed` if closed.
+    #[cfg(target_family = "wasm")]
+    #[instrument(skip_all)]
+    async fn read(&self) -> Result<SqliteAsyncConn> {
+        let guard = self.connections.lock().await;
+        let conns = guard.as_ref().ok_or(Error::StoreClosed)?;
+        Ok(conns.conn.clone())
+    }
+
     #[instrument(skip_all)]
     async fn write(&self) -> Result<OwnedMutexGuard<SqliteAsyncConn>> {
         let write_conn = {
@@ -900,7 +960,8 @@ impl SqliteConnectionStateStoreExt for rusqlite::Connection {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
     async fn get_kv_blob(&self, key: Key) -> Result<Option<Vec<u8>>> {
         Ok(self
@@ -1137,6 +1198,7 @@ trait SqliteObjectStateStoreExt: SqliteAsyncConnExt {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 #[async_trait]
 impl SqliteObjectStateStoreExt for SqliteAsyncConn {
     async fn set_kv_blob(&self, key: Key, value: Vec<u8>) -> Result<()> {
@@ -1144,7 +1206,16 @@ impl SqliteObjectStateStoreExt for SqliteAsyncConn {
     }
 }
 
-#[async_trait]
+#[cfg(target_family = "wasm")]
+#[async_trait(?Send)]
+impl SqliteObjectStateStoreExt for SqliteAsyncConn {
+    async fn set_kv_blob(&self, key: Key, value: Vec<u8>) -> Result<()> {
+        Ok(self.interact(move |conn| conn.set_kv_blob(&key, &value))?)
+    }
+}
+
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 impl StateStore for SqliteStateStore {
     type Error = Error;
 
@@ -2401,13 +2472,21 @@ impl StateStore for SqliteStateStore {
     }
 
     async fn reopen(&self) -> Result<(), Self::Error> {
-        connection::reopen_connections(
-            &self.connections,
-            self.db_path.clone(),
-            self.pool_config,
-            self.runtime_config,
-        )
-        .await?;
+        #[cfg(not(target_family = "wasm"))]
+        {
+            connection::reopen_connections(
+                &self.connections,
+                self.db_path.clone(),
+                self.pool_config,
+                self.runtime_config,
+            )
+            .await?;
+        }
+        #[cfg(target_family = "wasm")]
+        {
+            connection::reopen_connections(&self.connections, &self.db_name, self.runtime_config)
+                .await?;
+        }
         Ok(())
     }
 }
@@ -2419,7 +2498,7 @@ struct ReceiptData {
     user_id: OwnedUserId,
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod tests {
     use std::sync::{
         LazyLock,
@@ -2446,7 +2525,7 @@ mod tests {
     statestore_integration_tests!();
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod encrypted_tests {
     use std::{
         path::PathBuf,
@@ -2530,7 +2609,7 @@ mod encrypted_tests {
     statestore_integration_tests!();
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod migration_tests {
     use std::{
         path::{Path, PathBuf},
@@ -2954,7 +3033,7 @@ mod migration_tests {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod close_reopen_tests {
     use std::sync::{
         LazyLock,
@@ -3178,5 +3257,57 @@ mod close_reopen_tests {
         // Verify the store is fully closed.
         let guard = store.connections.lock().await;
         assert!(guard.is_none(), "connections should be None after close");
+    }
+}
+
+/// Smoke tests for the WASM backend.
+///
+/// They must run in a dedicated Web Worker, because OPFS synchronous access
+/// handles are not available on the main thread. Run them with e.g.
+/// `wasm-pack test --chrome --headless`.
+#[cfg(all(test, target_family = "wasm"))]
+mod wasm_tests {
+    use matrix_sdk_base::{StateStore, StateStoreDataKey, StateStoreDataValue};
+    use wasm_bindgen_test::wasm_bindgen_test;
+
+    use super::SqliteStateStore;
+    use crate::utils::SqliteAsyncConnExt;
+
+    wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_dedicated_worker);
+
+    #[wasm_bindgen_test]
+    async fn test_smoke() {
+        let store = SqliteStateStore::open("test-state-store-smoke", None).await.unwrap();
+
+        // WAL must actually be enabled. The sahpool VFS has no shared-memory
+        // support, which SQLite only tolerates in exclusive locking mode; if
+        // the `journal_mode` PRAGMA silently failed to switch, this would
+        // return e.g. "delete".
+        let journal_mode: String = store
+            .read()
+            .await
+            .unwrap()
+            .query_row("PRAGMA journal_mode;", (), |row| row.get(0))
+            .await
+            .unwrap();
+        assert_eq!(journal_mode, "wal");
+
+        // Data must survive a close/reopen cycle.
+        store
+            .set_kv_data(
+                StateStoreDataKey::SyncToken,
+                StateStoreDataValue::SyncToken("sync-token".to_owned()),
+            )
+            .await
+            .unwrap();
+
+        store.close().await.unwrap();
+        store.reopen().await.unwrap();
+
+        let value = store.get_kv_data(StateStoreDataKey::SyncToken).await.unwrap();
+        assert!(
+            matches!(value, Some(StateStoreDataValue::SyncToken(token)) if token == "sync-token"),
+            "the sync token should survive a close/reopen cycle",
+        );
     }
 }

--- a/crates/matrix-sdk-sqlite/src/utils.rs
+++ b/crates/matrix-sdk-sqlite/src/utils.rs
@@ -21,6 +21,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+#[cfg(not(target_family = "wasm"))]
 use deadpool_sync::InteractError;
 use itertools::Itertools;
 use matrix_sdk_store_encryption::StoreCipher;
@@ -65,7 +66,8 @@ impl rusqlite::ToSql for Key {
     }
 }
 
-#[async_trait]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub(crate) trait SqliteAsyncConnExt {
     async fn execute<P>(
         &self,
@@ -114,9 +116,15 @@ pub(crate) trait SqliteAsyncConnExt {
         E: From<rusqlite::Error> + Send + 'static,
         F: FnOnce(&Transaction<'_>) -> Result<T, E> + Send + 'static;
 
+    /// Chunk a large query over some keys.
+    ///
+    /// Imagine there is a _dynamic_ query that runs potentially large number of
+    /// parameters, so much that the maximum number of parameters can be hit.
+    /// Then, this helper is for you. It will execute the query on chunks of
+    /// parameters.
     async fn chunk_large_query_over<Query, Res>(
         &self,
-        mut keys_to_chunk: Vec<Key>,
+        keys_to_chunk: Vec<Key>,
         result_capacity: Option<usize>,
         do_query: Query,
     ) -> Result<Vec<Res>>
@@ -240,6 +248,11 @@ pub(crate) trait SqliteAsyncConnExt {
     }
 }
 
+// ===========================================================================
+// Native implementation — delegates to SyncWrapper::interact
+// ===========================================================================
+
+#[cfg(not(target_family = "wasm"))]
 #[async_trait]
 impl SqliteAsyncConnExt for SqliteAsyncConn {
     async fn execute<P>(
@@ -325,12 +338,6 @@ impl SqliteAsyncConnExt for SqliteAsyncConn {
         .map_err(E::from)?
     }
 
-    /// Chunk a large query over some keys.
-    ///
-    /// Imagine there is a _dynamic_ query that runs potentially large number of
-    /// parameters, so much that the maximum number of parameters can be hit.
-    /// Then, this helper is for you. It will execute the query on chunks of
-    /// parameters.
     async fn chunk_large_query_over<Query, Res>(
         &self,
         keys_to_chunk: Vec<Key>,
@@ -353,6 +360,7 @@ impl SqliteAsyncConnExt for SqliteAsyncConn {
 /// An [`InteractError::Panic`] will panic. An [`InteractError::Cancelled`] will
 /// generate a [`rusqlite::Error::SqliteFailure`] with the
 /// [`rusqlite::ffi::SQLITE_ABORT`] code.
+#[cfg(not(target_family = "wasm"))]
 fn map_interact_err(error: InteractError) -> rusqlite::Error {
     match error {
         InteractError::Panic(p) => panic!("{p:?}"),
@@ -362,6 +370,106 @@ fn map_interact_err(error: InteractError) -> rusqlite::Error {
         ),
     }
 }
+
+// ===========================================================================
+// WASM implementation — calls synchronous rusqlite API inline
+// ===========================================================================
+
+#[cfg(target_family = "wasm")]
+#[async_trait(?Send)]
+impl SqliteAsyncConnExt for SqliteAsyncConn {
+    async fn execute<P>(
+        &self,
+        sql: impl AsRef<str> + Send + 'static,
+        params: P,
+    ) -> rusqlite::Result<usize>
+    where
+        P: Params + Send + 'static,
+    {
+        self.interact(move |conn| conn.execute(sql.as_ref(), params))
+    }
+
+    async fn execute_batch(&self, sql: impl AsRef<str> + Send + 'static) -> rusqlite::Result<()> {
+        self.interact(move |conn| conn.execute_batch(sql.as_ref()))
+    }
+
+    async fn prepare<T, F>(
+        &self,
+        sql: impl AsRef<str> + Send + 'static,
+        f: F,
+    ) -> rusqlite::Result<T>
+    where
+        T: Send + 'static,
+        F: FnOnce(Statement<'_>) -> rusqlite::Result<T> + Send + 'static,
+    {
+        self.interact(move |conn| f(conn.prepare(sql.as_ref())?))
+    }
+
+    async fn query_row<T, P, F>(
+        &self,
+        sql: impl AsRef<str> + Send + 'static,
+        params: P,
+        f: F,
+    ) -> rusqlite::Result<T>
+    where
+        T: Send + 'static,
+        P: Params + Send + 'static,
+        F: FnOnce(&Row<'_>) -> rusqlite::Result<T> + Send + 'static,
+    {
+        self.interact(move |conn| conn.query_row(sql.as_ref(), params, f))
+    }
+
+    async fn query_many<T, P, F>(
+        &self,
+        sql: impl AsRef<str> + Send + 'static,
+        params: P,
+        f: F,
+    ) -> rusqlite::Result<Vec<T>>
+    where
+        T: Send + 'static,
+        P: Params + Send + 'static,
+        F: FnMut(&Row<'_>) -> rusqlite::Result<T> + Send + 'static,
+    {
+        self.interact(move |conn| {
+            let mut stmt = conn.prepare(sql.as_ref())?;
+            stmt.query_and_then(params, f)?.collect()
+        })
+    }
+
+    async fn with_transaction<T, E, F>(&self, f: F) -> Result<T, E>
+    where
+        T: Send + 'static,
+        E: From<rusqlite::Error> + Send + 'static,
+        F: FnOnce(&Transaction<'_>) -> Result<T, E> + Send + 'static,
+    {
+        self.interact(move |conn| {
+            let txn = conn.transaction()?;
+            let result = f(&txn)?;
+            txn.commit()?;
+            Ok(result)
+        })
+    }
+
+    async fn chunk_large_query_over<Query, Res>(
+        &self,
+        keys_to_chunk: Vec<Key>,
+        result_capacity: Option<usize>,
+        do_query: Query,
+    ) -> Result<Vec<Res>>
+    where
+        Res: Send + 'static,
+        Query: Fn(&Transaction<'_>, Vec<Key>) -> Result<Vec<Res>> + Send + 'static,
+    {
+        self.with_transaction(move |txn| {
+            txn.chunk_large_query_over(keys_to_chunk, result_capacity, do_query)
+        })
+        .await
+    }
+}
+
+// ===========================================================================
+// Shared helpers (both targets)
+// ===========================================================================
 
 pub(crate) trait SqliteTransactionExt {
     fn chunk_large_query_over<Key, Query, Res>(
@@ -477,7 +585,8 @@ impl SqliteKeyValueStoreConnExt for rusqlite::Connection {
 ///     "value" BLOB NOT NULL
 /// );
 /// ```
-#[async_trait]
+#[cfg_attr(target_family = "wasm", async_trait(?Send))]
+#[cfg_attr(not(target_family = "wasm"), async_trait)]
 pub(crate) trait SqliteKeyValueStoreAsyncConnExt: SqliteAsyncConnExt {
     /// Whether the `kv` table exists in this database.
     async fn kv_table_exists(&self) -> rusqlite::Result<bool> {
@@ -569,12 +678,12 @@ pub(crate) trait SqliteKeyValueStoreAsyncConnExt: SqliteAsyncConnExt {
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 #[async_trait]
 impl SqliteKeyValueStoreAsyncConnExt for SqliteAsyncConn {
     async fn set_kv(&self, key: &str, value: Vec<u8>) -> rusqlite::Result<()> {
         let key = key.to_owned();
         self.interact(move |conn| conn.set_kv(&key, &value)).await.unwrap()?;
-
         Ok(())
     }
 
@@ -585,14 +694,38 @@ impl SqliteKeyValueStoreAsyncConnExt for SqliteAsyncConn {
     ) -> Result<()> {
         let key = key.to_owned();
         self.interact(move |conn| conn.set_serialized_kv(&key, value)).await.unwrap()?;
-
         Ok(())
     }
 
     async fn clear_kv(&self, key: &str) -> rusqlite::Result<()> {
         let key = key.to_owned();
         self.interact(move |conn| conn.clear_kv(&key)).await.unwrap()?;
+        Ok(())
+    }
+}
 
+#[cfg(target_family = "wasm")]
+#[async_trait(?Send)]
+impl SqliteKeyValueStoreAsyncConnExt for SqliteAsyncConn {
+    async fn set_kv(&self, key: &str, value: Vec<u8>) -> rusqlite::Result<()> {
+        let key = key.to_owned();
+        self.interact(move |conn| conn.set_kv(&key, &value))?;
+        Ok(())
+    }
+
+    async fn set_serialized_kv<T: Serialize + Send + 'static>(
+        &self,
+        key: &str,
+        value: T,
+    ) -> Result<()> {
+        let key = key.to_owned();
+        self.interact(move |conn| conn.set_serialized_kv(&key, value))?;
+        Ok(())
+    }
+
+    async fn clear_kv(&self, key: &str) -> rusqlite::Result<()> {
+        let key = key.to_owned();
+        self.interact(move |conn| conn.clear_kv(&key))?;
         Ok(())
     }
 }
@@ -706,7 +839,7 @@ pub(crate) trait EncryptableStore {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_family = "wasm")))]
 mod unit_tests {
     use std::time::Duration;
 

--- a/xtask/src/ci.rs
+++ b/xtask/src/ci.rs
@@ -163,6 +163,10 @@ enum WasmFeatureSet {
     /// Equivalent to `indexeddb-all-features`, `indexeddb-crypto` and
     /// `indexeddb-state`
     Indexeddb,
+    /// Check `matrix-sdk-sqlite` crate with all features
+    SqliteAllFeatures,
+    /// Check `matrix-sdk` crate with `sqlite` and `e2e-encryption` features
+    MatrixSdkSqliteStores,
 }
 
 impl CiArgs {
@@ -389,6 +393,11 @@ fn run_wasm_checks(cmd: Option<WasmFeatureSet>) -> Result<()> {
             WasmFeatureSet::IndexeddbState,
             "-p matrix-sdk-indexeddb --no-default-features --features state-store",
         ),
+        (WasmFeatureSet::SqliteAllFeatures, "-p matrix-sdk-sqlite --all-features"),
+        (
+            WasmFeatureSet::MatrixSdkSqliteStores,
+            "-p matrix-sdk --no-default-features --features js,sqlite,e2e-encryption",
+        ),
     ]);
 
     let sh = sh();
@@ -450,6 +459,10 @@ fn run_wasm_pack_tests(cmd: Option<WasmFeatureSet>, runner: WasmTestRunner) -> R
             WasmFeatureSet::IndexeddbState,
             ("crates/matrix-sdk-indexeddb", "--no-default-features --features state-store"),
         ),
+        // The sqlite smoke tests require OPFS and a dedicated worker, so they
+        // only run in browser runners (`--runner chrome` or `--runner
+        // firefox`), not on Node.js.
+        (WasmFeatureSet::SqliteAllFeatures, ("crates/matrix-sdk-sqlite", "")),
     ]);
 
     let sh = sh();


### PR DESCRIPTION
Add a `wasm32-unknown-unknown` backend to `matrix-sdk-sqlite`. On WASM the stores use a single `rusqlite` connection backed by the OPFS `sahpool` VFS instead of a `deadpool` connection pool, since the module runs inside a single Web Worker.
